### PR TITLE
Use passed dependencies

### DIFF
--- a/opencog/base/Dockerfile
+++ b/opencog/base/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install apt-transport-https software-properties-common sudo
 
 # Install repositories and dependencies
-ADD https://raw.githubusercontent.com/singnet/ocpkg/master/ocpkg \
-    /tmp/octool
+ARG OCPKG_URL=https://raw.githubusercontent.com/singnet/ocpkg/master/ocpkg
+ADD $OCPKG_URL /tmp/octool
 RUN apt-get install -y tzdata
 RUN chmod 755 /tmp/octool;  sync; /tmp/octool -rdpv -l default
 

--- a/opencog/docker-build.sh
+++ b/opencog/docker-build.sh
@@ -49,7 +49,11 @@ printf "Usage: ./%s [OPTIONS]
 ## Build singularitynet/opencog-deps image.
 build_opencog_deps() {
     echo "---- Starting build of singularitynet/opencog-deps ----"
-    docker build $CACHE_OPTION -t singularitynet/opencog-deps base
+    OCPKG_OPTION=""
+    if [ ! -z "$OCPKG_URL" ]; then
+        OCPKG_OPTION="--build-arg OCPKG_URL=$OCPKG_URL"
+    fi
+    docker build $CACHE_OPTION $OCPKG_OPTION -t singularitynet/opencog-deps base
     echo "---- Finished build of singularitynet/opencog-deps ----"
 }
 

--- a/opencog/docker-build.sh
+++ b/opencog/docker-build.sh
@@ -166,7 +166,11 @@ fi
 
 if [ $BUILD__POSTGRES_IMAGE ] ; then
     echo "---- Starting build of singularitynet/postgres ----"
-    docker build $CACHE_OPTION -t singularitynet/postgres postgres
+    ATOM_SQL_OPTION=""
+    if [ ! -z "$ATOM_SQL_URL" ]; then
+        ATOM_SQL_OPTION="--build-arg ATOM_SQL_URL=$ATOM_SQL_URL"
+    fi
+    docker build $CACHE_OPTION $ATOM_SQL_OPTION -t singularitynet/postgres postgres
     echo "---- Finished build of singularitynet/postgres ----"
 fi
 

--- a/opencog/docker-build.sh
+++ b/opencog/docker-build.sh
@@ -172,7 +172,14 @@ fi
 
 if [ $BUILD_RELEX_IMAGE ] ; then
     echo "---- Starting build of singularitynet/relex ----"
-    docker build $CACHE_OPTION -t singularitynet/relex relex
+    RELEX_OPTIONS=""
+    if [ ! -z "$RELEX_REPO" ]; then
+        RELEX_OPTIONS="--build-arg RELEX_REPO=$RELEX_REPO"
+    fi
+    if [ ! -z "$RELEX_BRANCH" ]; then
+        RELEX_OPTIONS="$RELEX_OPTIONS --build-arg RELEX_BRANCH=$RELEX_BRANCH"
+    fi
+    docker build $CACHE_OPTION $RELEX_OPTIONS -t singularitynet/relex relex
     echo "---- Finished build of singularitynet/relex ----"
 fi
 

--- a/opencog/postgres/Dockerfile
+++ b/opencog/postgres/Dockerfile
@@ -5,7 +5,8 @@ FROM postgres:9.5
 # TODO:  Change to build time argument. See https://github.com/docker/docker/issues/13490
 ENV POSTGRES_PASSWORD="cheese"
 
-ADD https://raw.githubusercontent.com/singnet/atomspace/master/opencog/persist/sql/multi-driver/atom.sql /tmp/atom.sql
+ARG ATOM_SQL_URL=https://raw.githubusercontent.com/singnet/atomspace/master/opencog/persist/sql/multi-driver/atom.sql
+ADD $ATOM_SQL_URL /tmp/atom.sql
 
 COPY configure.sh /docker-entrypoint-initdb.d/
 COPY start.sh /

--- a/opencog/relex/Dockerfile
+++ b/opencog/relex/Dockerfile
@@ -93,8 +93,10 @@ RUN cd link-grammar-5.*/; mvn install:install-file \
 RUN rm -rf * link-grammar*
 
 # Relex -- changes often
-ADD https://github.com/singnet/relex/archive/master.tar.gz master.tar.gz
-RUN tar -xvf master.tar.gz; cd relex-master; mvn install
+ARG RELEX_REPO=https://github.com/singnet/relex.git
+ARG RELEX_BRANCH=master
+RUN git clone --depth=1 -b $RELEX_BRANCH $RELEX_REPO relex
+RUN cd relex; mvn install
 
 # Create and switch user. The user is privileged, with no password
 # required.  That is, you can use sudo.
@@ -112,5 +114,5 @@ EXPOSE 4444
 ## link-grammar-server.sh port
 EXPOSE 9000
 
-WORKDIR /home/Downloads/relex-master/
+WORKDIR /home/Downloads/relex/
 CMD /bin/bash


### PR DESCRIPTION
Configure docker-build.sh script via environment variables to download specific versions of:
- `ocpkg` for `opencog-deps` image
- `relex` for `relex` image
- `atom.sql` from `atomspace` for `postres` image