### PR TITLE
Ubuntu 20.04 overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ buildbot/workspace/volume/opencog/
 
 # For opencog/minecraft containers
 opencog/minecraft/data/
+.DS_Store

--- a/opencog/base/Dockerfile
+++ b/opencog/base/Dockerfile
@@ -2,7 +2,7 @@
 #
 # docker build --no-cache -t singularitynet/opencog-deps .
 
-ARG VERSION=18.04
+ARG VERSION=20.04
 FROM ubuntu:${VERSION}
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -14,8 +14,9 @@ RUN apt-get -y install apt-transport-https software-properties-common sudo \
       wget tzdata
 
 # Install repositories and dependencies
-ARG OCPKG_URL=https://raw.githubusercontent.com/singnet/ocpkg/master/ocpkg
+ARG OCPKG_URL=https://raw.githubusercontent.com/ntoxeg/ocpkg/master/ocpkg
 ADD $OCPKG_URL /tmp/octool
+ADD https://www.abisource.com/downloads/link-grammar/5.8.0/link-grammar-5.8.0.tar.gz /tmp/
 RUN apt-get install -y tzdata
 RUN chmod 755 /tmp/octool;  sync; /tmp/octool -rdpv -l default
 
@@ -37,7 +38,7 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER opencog
 WORKDIR /home/opencog
 
-ARG INSTALL_HASKELL="yes"
+ARG INSTALL_HASKELL="no"
 RUN if [ ${INSTALL_HASKELL} = "yes" ]; then /tmp/octool -s; fi
 
 # For images built on this

--- a/opencog/base/Dockerfile
+++ b/opencog/base/Dockerfile
@@ -14,10 +14,13 @@ RUN apt-get -y install apt-transport-https software-properties-common sudo \
       wget tzdata
 
 # Install repositories and dependencies
-ARG OCPKG_URL=https://raw.githubusercontent.com/ntoxeg/ocpkg/master/ocpkg
-ADD $OCPKG_URL /tmp/octool
-ADD https://www.abisource.com/downloads/link-grammar/5.8.0/link-grammar-5.8.0.tar.gz /tmp/
+ARG OCPKG_URL=https://raw.githubusercontent.com/singnet/ocpkg/master/ocpkg
+ADD ${OCPKG_URL} /tmp/octool
+ARG LINKGRAMMAR_URL=https://www.abisource.com/downloads/link-grammar/5.8.0/link-grammar-5.8.0.tar.gz
+ADD ${LINKGRAMMAR_URL} /tmp/
 RUN apt-get install -y tzdata
+ARG GITHUB_NAME="singnet"
+ENV GITHUB_NAME ${GITHUB_NAME}
 RUN chmod 755 /tmp/octool;  sync; /tmp/octool -rdpv -l default
 
 # Environment Variables

--- a/opencog/cogutil/Dockerfile
+++ b/opencog/cogutil/Dockerfile
@@ -1,12 +1,12 @@
 # Step to take
-# 1. docker build --no-cache -t singularitynet/cogutil
-# 2. docker run --rm -it singularitynet/cogutil
+# 1. docker build --no-cache -t synthillect/cogutil
+# 2. docker run --rm -it synthillect/cogutil
 
-FROM singularitynet/opencog-deps
+FROM synthillect/opencog-deps
 
 # Install repositories and dependencies
 # FIXME: when octools auto-updates remove this.
-ADD https://raw.githubusercontent.com/singnet/ocpkg/master/ocpkg \
+ADD https://raw.githubusercontent.com/ntoxeg/ocpkg/master/ocpkg \
     /tmp/octool
 RUN chmod 755 /tmp/octool
 

--- a/opencog/cogutil/Dockerfile
+++ b/opencog/cogutil/Dockerfile
@@ -6,8 +6,10 @@ FROM synthillect/opencog-deps
 
 # Install repositories and dependencies
 # FIXME: when octools auto-updates remove this.
-ADD https://raw.githubusercontent.com/ntoxeg/ocpkg/master/ocpkg \
-    /tmp/octool
+ARG OCPKG_URL=https://raw.githubusercontent.com/singnet/ocpkg/master/ocpkg
+ADD ${OCPKG_URL} /tmp/octool
+ARG GITHUB_NAME="singnet"
+ENV GITHUB_NAME ${GITHUB_NAME}
 RUN chmod 755 /tmp/octool
 
 # Install cogutil

--- a/opencog/docker-build.sh
+++ b/opencog/docker-build.sh
@@ -25,74 +25,74 @@ usage() {
 printf "Usage: ./%s [OPTIONS]
 
   OPTIONS:
-    -a Pull all images needed for development from hub.docker.com/u/singularitynet/
-    -b Build singularitynet/opencog-deps image. It is the base image for
+    -a Pull all images needed for development from hub.docker.com/u/synthillect/
+    -b Build synthillect/opencog-deps image. It is the base image for
        tools, cogutil, cogserver, and the buildbot images.
-    -c Builds singularitynet/cogutil image. It will build singularitynet/opencog-deps
+    -c Builds synthillect/cogutil image. It will build synthillect/opencog-deps
        if it hasn't been built, as it forms its base image.
-    -e Builds singularitynet/minecraft image. It will build all needed images if they
+    -e Builds synthillect/minecraft image. It will build all needed images if they
        haven't already been built.
-    -j Builds singularitynet/jupyter image. It will add jupyter notebook to
-    singularitynet/opencog-dev:cli
-    -m Builds singularitynet/moses image.
-    -p Builds singularitynet/postgres image.
-    -r Builds singularitynet/relex image.
-    -t Builds singularitynet/opencog-dev:cli image. It will build
-    singularitynet/opencog-deps
-       and singularitynet/cogutil if they haven't been built, as they form its base
+    -j Builds synthillect/jupyter image. It will add jupyter notebook to
+    synthillect/opencog-dev:cli
+    -m Builds synthillect/moses image.
+    -p Builds synthillect/postgres image.
+    -r Builds synthillect/relex image.
+    -t Builds synthillect/opencog-dev:cli image. It will build
+    synthillect/opencog-deps
+       and synthillect/cogutil if they haven't been built, as they form its base
        images.
     -u This option signals all image builds to not use cache.
     -h This help message. \n" "$SELF_NAME"
 }
 
 # -----------------------------------------------------------------------------
-## Build singularitynet/opencog-deps image.
+## Build synthillect/opencog-deps image.
 build_opencog_deps() {
-    echo "---- Starting build of singularitynet/opencog-deps ----"
+    echo "---- Starting build of synthillect/opencog-deps ----"
     OCPKG_OPTION=""
     if [ ! -z "$OCPKG_URL" ]; then
         OCPKG_OPTION="--build-arg OCPKG_URL=$OCPKG_URL"
     fi
-    docker build $CACHE_OPTION $OCPKG_OPTION -t singularitynet/opencog-deps base
-    echo "---- Finished build of singularitynet/opencog-deps ----"
+    docker build $CACHE_OPTION $OCPKG_OPTION -t synthillect/opencog-deps base
+    echo "---- Finished build of synthillect/opencog-deps ----"
 }
 
-## If the singularitynet/opencog-deps image hasn't been built yet then build it.
+## If the synthillect/opencog-deps image hasn't been built yet then build it.
 check_opencog_deps() {
-    if [ -z "$(docker images singularitynet/opencog-deps | grep -i opencog-deps)" ]
+    if [ -z "$(docker images synthillect/opencog-deps | grep -i opencog-deps)" ]
     then build_opencog_deps
     fi
 }
 
 # -----------------------------------------------------------------------------
-## Build singularitynet/cogutil image.
+## Build synthillect/cogutil image.
 build_cogutil() {
     check_opencog_deps
-    echo "---- Starting build of singularitynet/cogutil ----"
-    docker build $CACHE_OPTION -t singularitynet/cogutil cogutil
-    echo "---- Finished build of singularitynet/cogutil ----"
+    echo "---- Starting build of synthillect/cogutil ----"
+    docker build $CACHE_OPTION -t synthillect/cogutil cogutil
+    echo "---- Finished build of synthillect/cogutil ----"
 
 }
 
-## If the singularitynet/cogutil image hasn't been built yet then build it.
+## If the synthillect/cogutil image hasn't been built yet then build it.
 check_cogutil() {
-    if [ -z "$(docker images singularitynet/cogutil | grep -i cogutil)" ]
+    if [ -z "$(docker images synthillect/cogutil | grep -i cogutil)" ]
     then build_cogutil
     fi
 }
 
 # -----------------------------------------------------------------------------
-## Build singularitynet/opencog-dev:cli image.
+## Build synthillect/opencog-dev:cli image.
 build_dev_cli() {
     check_cogutil
-    echo "---- Starting build of singularitynet/opencog-dev:cli ----"
-    docker build $CACHE_OPTION -t singularitynet/opencog-dev:cli tools/cli
-    echo "---- Finished build of singularitynet/opencog-dev:cli ----"
+    echo "---- Starting build of synthillect/opencog-dev:cli ----"
+    docker build $CACHE_OPTION -t synthillect/opencog-dev:cli tools/cli
+    echo "---- Finished build of synthillect/opencog-dev:cli ----"
 }
 
-## If the singularitynet/opencog-dev:cli image hasn't been built yet then build it.
+## If the synthillect/opencog-dev:cli image hasn't been built yet then build it.
 check_dev_cli() {
-    if [ -z "$(docker images singularitynet/opencog-dev:cli | grep -i opencog-dev)" ]
+    if [ -z "$(docker images synthillect/opencog-dev:cli | grep -i opencog-dev)" ]
     then build_dev_cli
     fi
 }
@@ -101,11 +101,11 @@ check_dev_cli() {
 ## Pull all images needed for development from hub.docker.com/u/opencog/
 pull_dev_images() {
   echo "---- Starting pull of opencog development images ----"
-  docker pull singularitynet/opencog-deps
-  docker pull singularitynet/cogutil
-  docker pull singularitynet/opencog-dev:cli
-  docker pull singularitynet/postgres
-  docker pull singularitynet/relex
+  docker pull synthillect/opencog-deps
+  docker pull synthillect/cogutil
+  docker pull synthillect/opencog-dev:cli
+  docker pull synthillect/postgres
+  docker pull synthillect/relex
   echo "---- Finished pull of opencog development images ----"
 }
 
@@ -152,30 +152,30 @@ fi
 
 if [ $BUILD_EMBODIMENT_IMAGE ] ; then
     check_dev_cli
-    echo "---- Starting build of singularitynet/minecraft ----"
-    docker build $CACHE_OPTION -t singularitynet/minecraft:0.1.0 minecraft
-    echo "---- Finished build of singularitynet/minecraft ----"
+    echo "---- Starting build of synthillect/minecraft ----"
+    docker build $CACHE_OPTION -t synthillect/minecraft:0.1.0 minecraft
+    echo "---- Finished build of synthillect/minecraft ----"
 fi
 
 if [ $BUILD__MOSES_IMAGE ] ; then
     check_cogutil
-    echo "---- Starting build of singularitynet/moses ----"
-    docker build $CACHE_OPTION -t singularitynet/moses moses
-    echo "---- Finished build of singularitynet/moses ----"
+    echo "---- Starting build of synthillect/moses ----"
+    docker build $CACHE_OPTION -t synthillect/moses moses
+    echo "---- Finished build of synthillect/moses ----"
 fi
 
 if [ $BUILD__POSTGRES_IMAGE ] ; then
-    echo "---- Starting build of singularitynet/postgres ----"
+    echo "---- Starting build of synthillect/postgres ----"
     ATOM_SQL_OPTION=""
     if [ ! -z "$ATOM_SQL_URL" ]; then
         ATOM_SQL_OPTION="--build-arg ATOM_SQL_URL=$ATOM_SQL_URL"
     fi
-    docker build $CACHE_OPTION $ATOM_SQL_OPTION -t singularitynet/postgres postgres
-    echo "---- Finished build of singularitynet/postgres ----"
+    docker build $CACHE_OPTION $ATOM_SQL_OPTION -t synthillect/postgres postgres
+    echo "---- Finished build of synthillect/postgres ----"
 fi
 
 if [ $BUILD_RELEX_IMAGE ] ; then
-    echo "---- Starting build of singularitynet/relex ----"
+    echo "---- Starting build of synthillect/relex ----"
     RELEX_OPTIONS=""
     if [ ! -z "$RELEX_REPO" ]; then
         RELEX_OPTIONS="--build-arg RELEX_REPO=$RELEX_REPO"
@@ -183,15 +183,15 @@ if [ $BUILD_RELEX_IMAGE ] ; then
     if [ ! -z "$RELEX_BRANCH" ]; then
         RELEX_OPTIONS="$RELEX_OPTIONS --build-arg RELEX_BRANCH=$RELEX_BRANCH"
     fi
-    docker build $CACHE_OPTION $RELEX_OPTIONS -t singularitynet/relex relex
-    echo "---- Finished build of singularitynet/relex ----"
+    docker build $CACHE_OPTION $RELEX_OPTIONS -t synthillect/relex relex
+    echo "---- Finished build of synthillect/relex ----"
 fi
 
 if [ $BUILD_JUPYTER_IMAGE ]; then
     check_dev_cli
-    echo "---- Starting build of singularitynet/jupyter ----"
-    docker build $CACHE_OPTION -t singularitynet/jupyter tools/jupyter_notebook
-    echo "---- Finished build of singularitynet/jupyter ----" 
+    echo "---- Starting build of synthillect/jupyter ----"
+    docker build $CACHE_OPTION -t synthillect/jupyter tools/jupyter_notebook
+    echo "---- Finished build of synthillect/jupyter ----" 
 fi
 
 if [ $UNKNOWN_FLAGS ] ; then usage; exit 1 ; fi

--- a/opencog/tools/cli/Dockerfile
+++ b/opencog/tools/cli/Dockerfile
@@ -1,24 +1,24 @@
 # For creating images with non gui tools for development and dependencies installed
 # Steps:
-# 1. docker build -t singularitynet/opencog-dev:cli .
+# 1. docker build -t synthillect/opencog-dev:cli .
 # 2. docker create --name opencog -p 17001:17001 -p 5000:5000
 #       -v ABSOLUTE/PATH/TO/OPENCOG/ROOT/DIRECTORY/On/Your/PC/:/opencog
 #       -w /opencog
-#       -it singularitynet/opencog-dev:cli
+#       -it synthillect/opencog-dev:cli
 # 3. docker start -i opencog
 # 4. mkdir build
 # 5. cmake ..
 # 6. make -j$(nproc)
 # Check http://wiki.opencog.org/w/Building_OpenCog on how to use IDEs
 
-FROM singularitynet/cogutil
+FROM synthillect/cogutil
 
 # Downlaod data and install atomspace & opencog.
 RUN  /tmp/octool -aow ; ccache -C
 
 # Install tools for developers.
 RUN apt-get -y install telnet netcat-openbsd less vim python3-dbg \
-                       tmux man valgrind gdb byobu
+    tmux man valgrind gdb byobu
 
 USER opencog
 WORKDIR /home/opencog

--- a/opencog/tools/jupyter_notebook/Dockerfile
+++ b/opencog/tools/jupyter_notebook/Dockerfile
@@ -1,7 +1,7 @@
 # For interacting with jupter notebooks. This installs a kernel for python and guile.
 
 # Build from opencog-dev:cli as it has all packages it needs.
-FROM singularitynet/opencog-dev:cli
+FROM synthillect/opencog-dev:cli
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 \
@@ -10,7 +10,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
 
 # To install jupyter notebook alongside with kernel on default python3 for later usage
 # torando must be at this specific version from https://github.com/jupyter/notebook/issues/3407
-RUN python3 -m pip install jupyter ipykernel tornado==4.5.3
+RUN python3 -m pip install jupyter ipykernel tornado
 
 # Install guile-json as it is needed for guile-kernel
 WORKDIR /opt/

--- a/opencog/tools/jupyter_notebook/Dockerfile
+++ b/opencog/tools/jupyter_notebook/Dockerfile
@@ -8,9 +8,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     git mercurial subversion \
     curl python3-pip
 
-# To install jupyter notebook alongside with kernel on default python3 for later usage
-# torando must be at this specific version from https://github.com/jupyter/notebook/issues/3407
-RUN python3 -m pip install jupyter ipykernel tornado
+RUN python3 -m pip install jupyterlab ipykernel tornado
 
 # Install guile-json as it is needed for guile-kernel
 WORKDIR /opt/
@@ -21,9 +19,12 @@ RUN wget https://download.savannah.gnu.org/releases/guile-json/guile-json-0.6.0.
     cd guile-json-0.6.0 && \
     ./configure && \
     make install
+# Why does it install in the wrong directory?
+# RUN mkdir -p /usr/local/share/guile/site/2.2/
+RUN mv /usr/local/share/guile/site/json* /usr/share/guile/site/2.2/
 
 # ZMQ library to enable communication with jupyter notebook
-RUN wget https://raw.githubusercontent.com/jerry40/guile-simple-zmq/master/src/simple-zmq.scm -O /usr/local/share/guile/site/simple-zmq.scm
+RUN wget https://raw.githubusercontent.com/jerry40/guile-simple-zmq/master/src/simple-zmq.scm -O /usr/share/guile/site/2.2/simple-zmq.scm
 
 # Create a directory with the guile kernel in jupyter notebook kernels directory
 WORKDIR /usr/local/share/jupyter/kernels
@@ -34,4 +35,4 @@ COPY kernel.json /usr/local/share/jupyter/kernels/guile-kernel
 
 EXPOSE 8888
 USER opencog
-CMD [ "jupyter", "notebook", "--ip=0.0.0.0", "--port=8888" ]
+CMD [ "jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser" ]


### PR DESCRIPTION
This is one of the three opened pull requests opened among OpenCog projects that changes and fixes a few scripts such that you can build and use OpenCog on the new LTS Ubuntu 20.04, coming out this April.

Unfortunately, there is a small fix that I had to apply to Cogutil, so these changes **are not** backward-compatible.

What changed here is as follows:
- I couldn't download link-grammar with wget in the container because of some SSL bug, so I hardcoded the version and it is downloaded by Docker itself (you can set an environment variable with URL to it though).
- I wanted the ability to easily change what DockerHub / GitHub username I use, so these are now optional arguments that you pass after options (they default to "singularitynet" / "singlet").
- Formatted the script.
- Fixed Scheme modules for the Guile kernel being placed where Guile doesn't look by default. (The kernel is still broken and I've raised the issue with the author).
- Switched to Jupiter Lab by default as it's superior in capability to just plain Jupyter.

Again, this is not backwards-compatible so I'm just leaving this here in case some day you want to move to 20.04 so perhaps this will save you time.